### PR TITLE
add ohvolume widget

### DIFF
--- a/widgets/ohvolume/README
+++ b/widgets/ohvolume/README
@@ -1,0 +1,1 @@
+Similar to ohdimmer widget. Only difference is that it increments/decrements by 5 instead of 10, and that turning it ON from an OFF state will set it to 20 instead of 100. For music volume control.

--- a/widgets/ohvolume/ohvolume.coffee
+++ b/widgets/ohvolume/ohvolume.coffee
@@ -1,0 +1,88 @@
+class Dashing.Ohvolume extends Dashing.ClickableWidget
+  constructor: ->
+    super
+    @queryState()
+
+  @accessor 'state',
+    get: -> @_state ? '0'
+    set: (key, value) -> @_state = value
+
+
+  @accessor 'icon',
+    get: -> if @['icon'] then @['icon'] else
+      if parseInt(@get('state')) > 0 then @get('iconon') else @get('iconoff')
+    set: Batman.Property.defaultAccessor.set
+
+  @accessor 'iconon',
+    get: -> @['iconon'] ? 'circle'
+    set: Batman.Property.defaultAccessor.set
+
+  @accessor 'iconoff',
+    get: -> @['iconoff'] ? 'circle-thin'
+    set: Batman.Property.defaultAccessor.set
+
+  @accessor 'icon-style', ->
+    if parseInt(@get('state')) >0 then 'volume-icon-on' else 'volume-icon-off' 
+
+  plusLevel: ->
+    newLevel = parseInt(@get('state'))+5
+    if newLevel > 100
+      newLevel = 100
+    else if newLevel < 0
+      newLevel = 0
+    @set 'state', newLevel
+    return @get('state')
+
+  minusLevel: ->
+    newLevel = parseInt(@get('state'))-5
+    if newLevel > 100
+      newLevel = 100
+    else if newLevel < 0
+      newLevel = 0
+    @set 'state', newLevel
+    return @get('state')
+
+  levelUp: ->
+    newLevel = @plusLevel()
+    $.post '/openhab/dispatch',
+      deviceId: @get('device'),
+      command: newLevel    
+
+  levelDown: ->
+    newLevel = @minusLevel()
+    $.post '/openhab/dispatch',
+      deviceId: @get('device'),
+      command: newLevel     
+
+  toggleState: ->
+    newState = if @get('state') > 0  then '0' else '20'
+    @set 'state', newState
+    return newState
+
+  queryState: ->
+   $.get '/openhab/dispatch',
+      widgetId: @get('id'),
+      deviceId: @get('device'),
+      deviceType: 'switch'
+      (data) =>
+        json = JSON.parse data
+        @set 'state', json.state
+    
+  postState: ->
+    newState = @toggleState()
+    $.post '/openhab/dispatch',
+      deviceId: @get('device'),
+      command: newState     
+
+  ready: ->
+
+  onData: (data) ->
+    debugger
+
+  onClick: (event) ->
+    if event.target.id == "level-down"
+      @levelDown()
+    else if event.target.id == "level-up"
+      @levelUp()
+    else if event.target.id == "switch"
+      @postState()

--- a/widgets/ohvolume/ohvolume.html
+++ b/widgets/ohvolume/ohvolume.html
@@ -1,0 +1,8 @@
+<h1 class="title" data-bind="title"></h1>
+
+<h2 data-bind-class="icon-style"><i data-bind-class="icon | prepend 'fa fa-'"></i></h2>
+<span class="toggle-area" id="switch"></span>
+<p class="level" data-bind="state"></p>
+<p class="unit">%</p>
+<p class="secondary-icon minus"><i class="fa fa-minus" id="level-down"></i></p>
+<p class="secondary-icon plus"><i class="fa fa-plus" id="level-up"></i></p>

--- a/widgets/ohvolume/ohvolume.scss
+++ b/widgets/ohvolume/ohvolume.scss
@@ -1,0 +1,73 @@
+// ----------------------------------------------------------------------------
+// Widget styles
+// ----------------------------------------------------------------------------
+.widget-ohvolume {
+
+  background-color: #444 !important;
+  position: relative;
+
+  .title {
+    color: #fff;
+    margin-bottom: 0;
+    margin-top: 10px;
+  }
+
+  .volume-icon-off .volume-icon-on {
+    font-size: 150%;
+  }
+
+  .volume-icon-off {
+    color: #888888;
+  }
+
+  .volume-icon-on {
+    color: #aaff00;
+  }
+
+  .toggle-area {
+    z-index: 10;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100px;
+  }
+
+  .level {
+    display: inline-block;
+    margin-bottom: 5px;
+    color: rgba(255, 255, 255, 0.7);
+  }
+
+  .unit {
+    display: inline-block;
+    color: rgba(255, 255, 255, 0.7);
+  }
+
+  .secondary-icon {
+    position: absolute;
+    bottom: 0px;
+    font-size: 25px;
+    width: 32px;
+    color: #888888;
+
+    &.plus {
+      right: 24px;
+
+      i {
+        padding-top: 10px;
+        padding-left: 30px;
+      }
+    }
+
+    &.minus {
+      left: 8px;
+
+      i {
+        padding-top: 10px;
+        padding-right: 30px;
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
basically a copy of the ohdimmer widget.  Only difference is that it increments/decrements by 5 instead of 10, and that turning it ON from an OFF state will set it to 20 instead of 100.  I am using it for squeezebox volume control.  Decided it needed to be different from ohdimmer after blowing my eardrums out with an accidental ON press...
